### PR TITLE
Add $slot to selected option display

### DIFF
--- a/resources/views/components/select/option.blade.php
+++ b/resources/views/components/select/option.blade.php
@@ -5,7 +5,7 @@
         'dark:focus:bg-secondary-700' => !($readonly || $disabled),
         'opacity-60 cursor-not-allowed' => $disabled
     ])->merge([
-        'data-label' => $label,
+        'data-label' => $label ?? $slot,
         'data-value' => $value,
     ]) }}
     @unless($readonly || $disabled)


### PR DESCRIPTION
When using the $slot for a custom label the field would show 'undefined' after option is selected.