### PR TITLE
fix: correct militaryTime boolean conversion in Alpine props

### DIFF
--- a/src/Components/TimePicker/views/picker.blade.php
+++ b/src/Components/TimePicker/views/picker.blade.php
@@ -83,7 +83,7 @@
                 :component="WireUi::component('time-selector')"
                 :name="$name . ':raw'"
                 x-model="value"
-                :military-time="$militaryTime"
+                :military-time="$militaryTime === 'true' || !$militaryTime"
                 :without-seconds="$withoutSeconds"
                 :disabled="$disabled"
                 :readonly="$readonly"


### PR DESCRIPTION
### Description
Correct militaryTime boolean conversion in Alpine props
https://github.com/wireui/wireui/issues/1074