### PR TITLE
Prevent Using null as an array offset is deprecated, use an empty str…

### DIFF
--- a/src/Components/Wrapper/views/text-field.blade.php
+++ b/src/Components/Wrapper/views/text-field.blade.php
@@ -62,7 +62,7 @@
 
                 '!bg-gray-100 bg-gray-100!' => $disabled && !$invalidated,
 
-                $padding =>  $padding,
+                ($padding ?? '') =>  $padding,
                 'pl-3'   => !$padding && !isset($prepend),
                 'pr-3'   => !$padding && !isset($append),
                 'py-2'   => !$padding && !isset($prepend) && !isset($append),


### PR DESCRIPTION
Prevent Using null as an array offset is deprecated, use an empty string instead 
when $padding is null